### PR TITLE
Reviewed: 42-fix-heading-parsing-on-obsidian

### DIFF
--- a/src/FileCollection/FileParser.ts
+++ b/src/FileCollection/FileParser.ts
@@ -196,9 +196,9 @@ class FileParser {
 					// Code looks weird but headingMatch is an array that basically contains: [ # complete title, #, title];.
 					// So we're just voiding the 0 index and assigning the remaining 2 indexes to hashes and title.
 					const [, hashes, title] = headingMatch;
-					const heading_level = hashes.length - 1;
+					const heading_level = hashes.length;
 
-					if(heading_level === 0){
+					if(heading_level === 1){
 						// Maintaining a list of H1s
 						listOfH1.push(title);
 					}

--- a/src/FileCollection/FileParser.ts
+++ b/src/FileCollection/FileParser.ts
@@ -223,7 +223,7 @@ class FileParser {
 							listOfSection.push({
 								title: '',
 								content: initialContent,
-								heading_level: 99,
+								heading_level: 0,
 								children: [],
 							});
 							initialContent = '';
@@ -260,7 +260,7 @@ class FileParser {
 			const initialSection: OeSection = {
 				title: '',
 				content: initialContent,
-				heading_level: 99,
+				heading_level: 0,
 				children: []
 			}
 


### PR DESCRIPTION
- [x] Bump each header level by 1 when parsing.